### PR TITLE
feat: minor revision for using rlrp scheduler

### DIFF
--- a/nbme_ner/medal_contender/model.py
+++ b/nbme_ner/medal_contender/model.py
@@ -131,7 +131,9 @@ def fetch_scheduler(optimizer, cfg, num_train_steps=None):
     elif SCHEDULER_LIST[cfg.model_param.scheduler] == 'ReduceLROnPlateau':
         scheduler = lr_scheduler.ReduceLROnPlateau(
             optimizer,
-            mode='min', min_lr=cfg.train_param.min_lr
+            mode='min',
+            patience=2,
+            min_lr=float(cfg.train_param.min_lr)
         )
     elif SCHEDULER_LIST[cfg.model_param.scheduler] == 'CyclicLR':
         scheduler = lr_scheduler.CyclicLR(

--- a/nbme_ner/medal_contender/train.py
+++ b/nbme_ner/medal_contender/train.py
@@ -71,7 +71,8 @@ def train_fn(CFG, fold, train_loader, model, criterion, optimizer, epoch, schedu
             optimizer.zero_grad()
             global_step += 1
             if CFG.train_param.batch_scheduler:
-                scheduler.step()
+                if not CFG.model_param.scheduler == 'rlrp':
+                    scheduler.step()
 
         running_loss += (loss.item() * batch_size)
         dataset_size += batch_size
@@ -85,7 +86,7 @@ def train_fn(CFG, fold, train_loader, model, criterion, optimizer, epoch, schedu
     return losses.avg
 
 
-def valid_fn(CFG, valid_loader, model, criterion, device, epoch):
+def valid_fn(CFG, valid_loader, model, criterion, epoch, scheduler, device):
     losses = AverageMeter()
     model.eval()
     preds = []
@@ -113,6 +114,8 @@ def valid_fn(CFG, valid_loader, model, criterion, device, epoch):
             Epoch=epoch,
             Valid_Loss=epoch_loss,
         )
+        if CFG.model_param.scheduler == 'rlrp':
+            scheduler.step(epoch_loss)
     predictions = np.concatenate(preds)
     return losses.avg, predictions
 

--- a/nbme_ner/run_train.py
+++ b/nbme_ner/run_train.py
@@ -77,7 +77,7 @@ def run_training(
 
         # eval
         avg_val_loss, predictions = valid_fn(
-            CFG, valid_loader, model, criterion, CFG.model_param.device, epoch)
+            CFG, valid_loader, model, criterion, epoch, scheduler, CFG.model_param.device)
 
         predictions = predictions.reshape((valid_fold_len, CFG.max_len))
 


### PR DESCRIPTION
[RLRP](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.ReduceLROnPlateau.html) optimizer의 경우 scheduler.step() 부분의 position과 argument가 달라서 수정하였습니다.

10 Fold, 10 Epoch, 2 patience 로 실험할 예정입니다.

