### PR TITLE
feat: edit making tokenizers

### DIFF
--- a/baseline1/run_train.py
+++ b/baseline1/run_train.py
@@ -22,7 +22,13 @@ from medal_contender.train import (
 )
 from colorama import Fore, Style
 
-# load_tokenizer(MAKE_TOKENIZER)
+# To make tokenizer in new environment, please operate the code below (3 line)
+'''
+from medal_contender.tokenizer import load_tokenizer
+from medal_contender.configs import MAKE_TOKENIZER
+load_tokenizer(MAKE_TOKENIZER)
+'''
+
 from transformers.models.deberta_v2 import DebertaV2TokenizerFast
 
 red_font = Fore.RED
@@ -35,6 +41,9 @@ warnings.filterwarnings("ignore")
 
 # CUDA가 구체적인 에러를 보고하도록 설정
 os.environ['CUDA_LAUNCH_BLOCKING'] = "1"
+
+# Tokenizer parallelism을 사용하도록 환경 설정
+os.environ["TOKENIZERS_PARALLELISM"] = "true" 
 
 
 def run_training(


### PR DESCRIPTION
1. 새로운 env에서 deberta large 모델의 tokenizer 생성이 가능하도록 변경.
주석 해제를 하면 바로 만들 수 있도록 코드 추가해두었습니다.

2. tokenizer parallelism 사용 가능하도록 환경 설정 
현재 run_train.py파일 실행 시 아래와 같은 오류가 나오고 있습니다.
`huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
        - Avoid using `tokenizers` before the fork if possible
        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)`
현재 kaggle top code들과 같이 tokenizer paralleism을 기본적으로 사용하는 env 설정하도록 추가하였습니다.
 